### PR TITLE
Reconfigure some SEXP declarations to fix compilation issues

### DIFF
--- a/src/dembase.h
+++ b/src/dembase.h
@@ -10,21 +10,22 @@
 //#define DEBUGGING
 
 /* everything in "x_sym" form here must be macro defined in init.c */
-SEXP indices_sym,
-     dims_sym,
-     dimBefore_sym,
-     dimAfter_sym,
-     invIndices_sym,
-     multiplierBefore_sym,
-     multiplierAfter_sym,
-     map_sym,
-     iTime_sym,
-     iOrigin_sym,
-     iDest_sym,
-     iDirection_sym,
-     iAge_sym,
-     iTriangle_sym,
-     dUpper_sym;
+// extern SEXP 
+//     indices_sym,
+//     dims_sym,
+//     dimBefore_sym,
+//     dimAfter_sym,
+//     invIndices_sym,
+//     multiplierBefore_sym,
+//     multiplierAfter_sym,
+//     map_sym,
+//     iTime_sym,
+//     iOrigin_sym,
+//     iDest_sym,
+//     iDirection_sym,
+//     iAge_sym,
+//     iTriangle_sym,
+//     dUpper_sym;
 
 
 /* array transformations */

--- a/src/init.c
+++ b/src/init.c
@@ -2,6 +2,22 @@
 #include "dembase.h"
 #include <R_ext/Rdynload.h>
 
+SEXP 
+    indices_sym,
+    dims_sym,
+    dimBefore_sym,
+    dimAfter_sym,
+    invIndices_sym,
+    multiplierBefore_sym,
+    multiplierAfter_sym,
+    map_sym,
+    iTime_sym,
+    iOrigin_sym,
+    iDest_sym,
+    iDirection_sym,
+    iAge_sym,
+    iTriangle_sym,
+    dUpper_sym;
 
 
 /* one off wrapper for rpoisDiffConstr_R */

--- a/src/miscellaneous-functions.c
+++ b/src/miscellaneous-functions.c
@@ -2,6 +2,23 @@
 #include "miscellaneous-functions.h"
 #include "dembase.h"
 
+extern SEXP 
+    indices_sym,
+    dims_sym,
+    dimBefore_sym,
+    dimAfter_sym,
+    invIndices_sym,
+    multiplierBefore_sym,
+    multiplierAfter_sym,
+    map_sym,
+    iTime_sym,
+    iOrigin_sym,
+    iDest_sym,
+    iDirection_sym,
+    iAge_sym,
+    iTriangle_sym,
+    dUpper_sym;
+
 /* utility functions for debugging printing */
 void printDblArray(double *a, int len)
 {   

--- a/src/transformArray.c
+++ b/src/transformArray.c
@@ -1,6 +1,23 @@
 
 #include "dembase.h"
 
+extern SEXP 
+    indices_sym,
+    dims_sym,
+    dimBefore_sym,
+    dimAfter_sym,
+    invIndices_sym,
+    multiplierBefore_sym,
+    multiplierAfter_sym,
+    map_sym,
+    iTime_sym,
+    iOrigin_sym,
+    iDest_sym,
+    iDirection_sym,
+    iAge_sym,
+    iTriangle_sym,
+    dUpper_sym;
+
 SEXP collapse_R(SEXP A, SEXP transform) {
     SEXP indices;
 


### PR DESCRIPTION
I was unable to compile the package on Fedora because of some issues with duplicate symbols. I tracked it down to the "SEXP" definitions at the top of `dembase.h`. 

I removed the definition from there, and defined them *once* at the top of `init.c`, and in the other header files expecting to see those variables (e.g., `miscellaneous-functions.h`) I declared them (using `extern SEXP ...`). It now seems to compile fine on Fedora. I'd suggest checking on Windows that compilation still works and perhaps that the code still runs as expected. I'm not a C developer :) and there's possibly a better way of doing this (without repeated declarations).
